### PR TITLE
Fixed bug that used cupy when not using gpu

### DIFF
--- a/FeatureExtractorSSVEP/featureExtractorMEC.py
+++ b/FeatureExtractorSSVEP/featureExtractorMEC.py
@@ -363,12 +363,18 @@ class FeatureExtractorMEC(FeatureExtractorTemplateMatching):
         snrs_reshaped = snrs_reshaped[ns]
         snrs = xp.reshape(snrs_reshaped, snrs.shape[0:2])
         
-        a = cp.asnumpy(snrs)
+        if self.use_gpu == True:
+            # Move to CPU memory if only CUDA gpu
+            a = cp.asnumpy(snrs)
+        else:
+            # If CPU, keep it as is. Assign to a to avoid error in the next line
+            a = snrs
+
         if np.isnan(a).any():
             b = 3
         
-        return snrs        
-                            
+        return snrs
+
     def project_signal(self, signal, y_bar_squared, device):
         """Project the signal such that noise has the minimum energy"""  
         xp = self.get_array_module(signal)


### PR DESCRIPTION
# Bug
Method `compute_snr` in `featureExtractorMEC.py` used CuPy (as cp), specifically cp.asnumpy, without being nested in self.use_gpu==True conditional.

As a result, this uses, or attempts to use, CuPy when use_gpu is False. Thus, this will fail on systems without a CUDA GPU or without CuPy installed in the environment.

# Fix
Fix is to add the `cp.asnumpy` method in a `if self.use_gpu==True` conditional. 

If use_gpu is False, then it will just assign the temporary variable a to the value on the CPU memory, where it already is located.